### PR TITLE
Fix hook dependencies and violating

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "extends": "react-app",
+  "extends": ["react-app", "plugin:react-hooks/recommended"],
   "rules": {
     "react/require-default-props": 2,
     "react/prop-types": 2,

--- a/package-lock.json
+++ b/package-lock.json
@@ -13381,6 +13381,12 @@
         "resolve": "^1.9.0"
       }
     },
+    "eslint-plugin-react-hooks": {
+      "version": "4.2.0",
+      "resolved": "https://npm.squarespace.net/api/npm/npm-all/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
+      "integrity": "sha1-jCKcJo1GiVYzTJQ7tF/IYCgPVVY=",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-react": "^7.12.4",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "jest": "^24.5.0",
     "lint-staged": "^8.1.4",
     "moment": "^2.24.0",

--- a/src/Calendar/components/DayGrid/utils/useTotalEventsToShow.js
+++ b/src/Calendar/components/DayGrid/utils/useTotalEventsToShow.js
@@ -1,4 +1,3 @@
-import get from 'lodash.get';
 import throttle from 'lodash.throttle';
 import { useRef, useState, useEffect } from 'react';
 import { addListener, removeListener } from 'resize-detector';
@@ -23,25 +22,26 @@ const useTotalEventsToShow = () => {
         setEventHeight(currentEventHeight);
       }
     }
-  });
-
-  const rowHeightThrottled = throttle(() => {
-    setRowHeight(get(rowRef, 'current.offsetHeight', 0));
-    setCellWidth(get(rowRef, 'current.offsetWidth', 0));
-  }, 300);
+  }, [eventHeight]);
 
   useEffect(() => {
-    if (rowRef.current) {
-      setRowHeight(rowRef.current.offsetHeight);
+    const rowHeightThrottled = throttle(() => {
+      setRowHeight(rowRef?.current?.offsetHeight || 0);
+      setCellWidth(rowRef?.current?.offsetWidth || 0);
+    }, 300);
+
+    const currentRowRef = rowRef.current;
+    if (currentRowRef) {
+      setRowHeight(currentRowRef.offsetHeight);
       setCellWidth(cellRef.current.offsetWidth);
-      addListener(rowRef.current, rowHeightThrottled);
+      addListener(currentRowRef, rowHeightThrottled);
     }
     return () => {
-      if (rowRef.current) {
-        return removeListener(rowRef.current, rowHeightThrottled);
+      if (currentRowRef) {
+        return removeListener(currentRowRef, rowHeightThrottled);
       }
     };
-  });
+  }, []);
 
   useEffect(() => {
     if (eventHeight > 0) {
@@ -49,13 +49,12 @@ const useTotalEventsToShow = () => {
         Math.floor((rowHeight - eventWrapperMargin) / eventHeight) - 1
       );
     }
-  }, [rowHeight, eventHeight]);
+  }, [rowHeight, eventHeight, eventWrapperMargin]);
 
   // Get the margin above all of the events
   useEffect(() => {
-    const newMargin = get(eventWrapperRef, 'current.offsetTop', 0);
-    setEventWrapperMargin(newMargin);
-  }, [get(eventWrapperRef, 'current.offsetTop', 0)]);
+    setEventWrapperMargin(eventWrapperRef?.current?.offsetTop || 0);
+  }, [eventWrapperRef?.current?.offsetTop]);
 
   return {
     rowRef,

--- a/src/Calendar/components/DayGrid/utils/useTotalEventsToShow.js
+++ b/src/Calendar/components/DayGrid/utils/useTotalEventsToShow.js
@@ -3,9 +3,6 @@ import { useState, useEffect, useCallback } from 'react';
 import { addListener, removeListener } from 'resize-detector';
 
 const useTotalEventsToShow = () => {
-  // const eventRef = useRef(null);
-  // const eventWrapperRef = useRef(null);
-  // const cellRef = useRef(null);
   const [rowNode, setRowNode] = useState(null);
   const [rowHeight, setRowHeight] = useState(0);
   const [cellWidth, setCellWidth] = useState(0);

--- a/src/Calendar/components/TimeGrid/components/Event/components/EventExtend.js
+++ b/src/Calendar/components/TimeGrid/components/Event/components/EventExtend.js
@@ -34,7 +34,7 @@ const EventExtend = ({
         selectMinutes,
         stepHeight,
       }),
-    [stepMinutes, selectMinutes]
+    [stepMinutes, selectMinutes, stepHeight]
   );
 
   const eventStartEnd = getDraggedEventStartEnd({

--- a/src/Calendar/components/TimeGrid/components/Event/index.js
+++ b/src/Calendar/components/TimeGrid/components/Event/index.js
@@ -30,7 +30,7 @@ const Event = ({
         setDragHandleCenterHeight(height);
       }
     }
-  });
+  }, [dragHandleCenterHeight]);
 
   return (
     <EventWrapper

--- a/src/Calendar/components/TimeGrid/index.js
+++ b/src/Calendar/components/TimeGrid/index.js
@@ -43,7 +43,7 @@ const TimeGrid = React.forwardRef(
       return () => {
         clearTimeout(timeout);
       };
-    });
+    }, [onCurrentTimeChange]);
 
     const {
       wrapperRef,
@@ -61,7 +61,7 @@ const TimeGrid = React.forwardRef(
         (stepHeight || STEP_HEIGHTS[stepMinutes]) * totalStepsPerBlock * 24 +
         (aggregateBorderHeight - 1 * STEP_BORDER_WIDTH * 25)
       );
-    }, [stepMinutes, stepHeight]);
+    }, [stepMinutes, stepHeight, totalStepsPerBlock]);
 
     useEffect(() => {
       if (scrollToTime) {
@@ -72,7 +72,7 @@ const TimeGrid = React.forwardRef(
         });
         wrapperRef.current.scrollTop = topOffset;
       }
-    }, [moment(selectedDate).format(), stepMinutes, stepHeight]);
+    }, [selectedDate, stepMinutes, stepHeight, scrollToTime, wrapperRef]);
 
     // Default to something sensible - but we're really getting the width from the element
     // so css can change the time gutter
@@ -82,9 +82,7 @@ const TimeGrid = React.forwardRef(
     }
 
     useEffect(() => {
-      if (scrollbarWidth === 0) {
-        setScrollbarWidth(getScrollbarWidth());
-      }
+      if (scrollbarWidth === 0) setScrollbarWidth(getScrollbarWidth());
     }, [scrollbarWidth]);
 
     const currentTimeIndicatorClass = makeClass(

--- a/src/Calendar/components/TimeGrid/utils/useCalendarSticky.js
+++ b/src/Calendar/components/TimeGrid/utils/useCalendarSticky.js
@@ -41,23 +41,17 @@ const useCalendarSticky = totalWidth => {
 
   // Add listener to wrapper to update when needed
   useEffect(() => {
-    if (!wrapperWidth) {
-      setWrapperWidth(get(wrapperRef, 'current.clientWidth'));
-    }
-
-    if (wrapperRef.current) {
-      addListener(wrapperRef.current, wrapperWidthThrottled);
-    }
-    return () => removeListener(wrapperRef.current, wrapperWidthThrottled);
-  });
+    const ref = wrapperRef.current;
+    if (!wrapperWidth) setWrapperWidth(get(wrapperRef, 'current.clientWidth'));
+    if (ref) addListener(ref, wrapperWidthThrottled);
+    return () => removeListener(ref, wrapperWidthThrottled);
+  }, [wrapperWidth, wrapperWidthThrottled]);
 
   useEffect(() => {
-    wrapperRef.current.addEventListener('scroll', onScroll, false);
-
-    return () => {
-      wrapperRef.current.removeEventListener('scroll', onScroll, false);
-    };
-  });
+    const ref = wrapperRef.current;
+    ref.addEventListener('scroll', onScroll, false);
+    return () => ref.removeEventListener('scroll', onScroll, false);
+  }, [onScroll]);
 
   return {
     wrapperRef,

--- a/src/Calendar/components/TimeGrid/utils/useElementWidths.js
+++ b/src/Calendar/components/TimeGrid/utils/useElementWidths.js
@@ -12,33 +12,28 @@ const useElementWidths = props => {
   const TimeGridRef = useRef(null);
   const [elementWidths, setElementWidths] = useState([]);
 
-  const getElementsMeasurements = () => {
-    const widths = [];
-    elementRefs.forEach((element, day) => {
-      widths.push(element.offsetWidth);
-    });
-    return widths;
-  };
-
-  const setAllWidths = () => {
-    if (!isEqual(getElementsMeasurements(), elementWidths)) {
-      setElementWidths(getElementsMeasurements());
-    }
-  };
-
-  const resizable = throttle(() => {
-    setAllWidths();
-  }, 300);
-
   useEffect(() => {
-    if (TimeGridRef.current) {
-      addListener(TimeGridRef.current, resizable);
-    }
-    setAllWidths();
-    return () => {
-      removeListener(TimeGridRef.current, resizable);
+    const getElementsMeasurements = () => {
+      const widths = [];
+      elementRefs.forEach((element, day) => {
+        widths.push(element.offsetWidth);
+      });
+      return widths;
     };
-  });
+
+    const setAllWidths = () => {
+      if (!isEqual(getElementsMeasurements(), elementWidths)) {
+        setElementWidths(getElementsMeasurements());
+      }
+    };
+
+    const resizable = throttle(() => setAllWidths(), 300);
+    const ref = TimeGridRef.current;
+
+    if (ref) addListener(ref, resizable);
+    setAllWidths();
+    return () => removeListener(ref, resizable);
+  }, [elementRefs, elementWidths]);
 
   // A function used to assign to the element for multiple refs
   // used like this ref={assignRef(key)}

--- a/src/Calendar/types.js
+++ b/src/Calendar/types.js
@@ -28,11 +28,14 @@ export const GROUP_TYPE = PropTypes.shape({
   id: PropTypes.number,
   name: PropTypes.string,
 });
-export const REF_TYPE = PropTypes.shape({
-  current: PropTypes.instanceOf(
-    typeof Element === 'undefined' ? function() {} : Element
-  ),
-});
+export const REF_TYPE = PropTypes.oneOfType([
+  PropTypes.func,
+  PropTypes.shape({
+    current: PropTypes.instanceOf(
+      typeof Element === 'undefined' ? function() {} : Element
+    ),
+  }),
+]);
 export const COLUMN_WIDTHS_TYPE = PropTypes.arrayOf(PropTypes.number);
 
 export const VIEWS_TYPE = PropTypes.arrayOf(

--- a/src/Calendar/utils/useMungeData.js
+++ b/src/Calendar/utils/useMungeData.js
@@ -12,7 +12,7 @@ const useMungeData = ({
 }) => {
   const mungedEvents = useMemo(
     () => getMungedEvents({ events, stepMinutes, stepHeight, withColumns }),
-    [events, stepMinutes, stepHeight]
+    [events, stepMinutes, stepHeight, withColumns]
   );
 
   const eventsWithSelectedEventGroups = useMemo(
@@ -21,41 +21,35 @@ const useMungeData = ({
         mungedEvents,
         visibleEventGroups,
       }),
-    [mungedEvents, visibleEventGroups, stepHeight]
+    [mungedEvents, visibleEventGroups]
   );
-
-  if (!stepDetails) {
-    return {
-      mungedEvents,
-      eventsWithSelectedEventGroups,
-    };
-  }
 
   const mungedStepDetails = useMemo(
     () =>
+      stepDetails &&
       getMungedEvents({
         events: stepDetails,
         stepMinutes,
         stepHeight,
         withColumns,
       }),
-    [stepDetails, stepMinutes, stepHeight]
+    [stepDetails, stepMinutes, stepHeight, withColumns]
   );
 
   const mungedStepDetailsGroups = useMemo(
     () =>
+      stepDetails &&
       getEventsWithEventGroups({
         mungedEvents: mungedStepDetails,
         visibleEventGroups,
       }),
-    [mungedStepDetails, visibleEventGroups, stepHeight]
+    [stepDetails, mungedStepDetails, visibleEventGroups]
   );
 
   return {
     mungedEvents,
     eventsWithSelectedEventGroups,
-    mungedStepDetails,
-    mungedStepDetailsGroups,
+    ...(stepDetails && { mungedStepDetails, mungedStepDetailsGroups }),
   };
 };
 

--- a/src/components/CalendarMonth/index.js
+++ b/src/components/CalendarMonth/index.js
@@ -32,8 +32,6 @@ const CalendarMonth = ({
     forceSixWeeks,
   });
 
-  console.log(monthGrid);
-
   return (
     <DayGrid
       isEventDraggable={isEventDraggable}

--- a/stories/stressTest.stories.js
+++ b/stories/stressTest.stories.js
@@ -7,7 +7,7 @@ import FullCalendar from '../src/components/FullCalendar';
 import EventGroupSelect from '../src/EventGroupSelect';
 import moment from 'moment';
 
-export const eventStressTest = () => {
+export const EventStressTest = () => {
   const numberOfEvents = number('numberOfEvents', 100);
   const spacing = number('eventSpacing', 0);
   const length = number('eventLength', 10);


### PR DESCRIPTION
- A number of `useEffect` hooks were missing dependency arrays
- A number of `useMemo` hooks had too many dependencies listed
- The custom `useMungeData` hook was violating the [top-level rule](https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level) of hooks by conditionally executing the latter two `useMemo` calls only if `stepDetails` was passed to the hook
- Replaced a few `lodash.get`s with optional chains instead